### PR TITLE
Refactor everything to new SQL schema

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV APP_USER_NAME='satamoto' \
     NODE_VERSION='v12.16.1'
 
 RUN apt-get update && \
-    apt-get install python curl jq vim -y && \
+    apt-get install python curl postgresql-client-10 jq vim -y && \
     apt-get clean && \
     rm -r /var/lib/apt/lists/* && \
     groupadd -g ${APP_GROUP_ID} ${APP_USER_NAME} && \
@@ -22,8 +22,7 @@ RUN cd /opt && \
     ln -s /opt/node-${NODE_VERSION}-linux-x64/bin/npm /usr/local/bin/npm && \
     rm node-${NODE_VERSION}-linux-x64.tar.xz
 
-USER root
-COPY package.json package-lock.json tsconfig.json tslint.json ${APP_HOME}/
+COPY package.json package-lock.json tsconfig.json tslint.json appConfig.json dbConfig.json rpcConfig.json ${APP_HOME}/
 COPY src ${APP_HOME}/src
 RUN cd ${APP_HOME} && \
     npm i --only=prod && \

--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@
 
 **NOTE**: This is not a stand-alone application. It is part of the project [satamotodb](https://github.com/tka85/satamotodb). Check out the [architecture plan](https://github.com/tka85/satamotodb/architecture.svg) for the various components.
 
-The bitcoin-sync image contains a Node.js application that exports Bitcoin's blockchain data (blocks, txs, inputs, outputs, addresses etc.) from a [satamotodb-bitcoin-node](https://github.com/tka85/satamotodb-bitcoin-node) and stores them in a Postgres database. Check satamotodb's [docker-compose.yml](https://github.com/tka85/satamotodb/blob/master/docker-compose.yml) to see how this image is used.
+The bitcoin-sync image contains a Node.js application that exports Bitcoin's blockchain data (blocks, txs, inputs, outputs, addresses etc.) from a [satamotodb-bitcoin-node](https://github.com/tka85/satamotodb-bitcoin-node) and stores them in a Postgres database. Check satamotodb's [docker-compose.yml](https://github.com/tka85/satamotodb/blob/master/docker-compose.yml) to see how this image is used and how it provides the config files needed by `satamotodb-bitcoin-sync` which here only contains empty configs:
+
+* appConfig.json
+* dbConfig.json
+* rpcConfig.json
+
 
 ## Reorg detection
 

--- a/appConfig.json
+++ b/appConfig.json
@@ -1,14 +1,15 @@
 {
+    "provided by the": "satamotodb project's docker-compose.yml",
     "debug": {
         "app": true,
-        "database": false,
+        "database": true,
         "branch": true,
         "block": true,
         "tx": true,
         "output": true,
         "input": true,
         "address": true,
-        "jsonrpc": false
+        "jsonrpc": true
     },
     "minConfirmations": 0
 }

--- a/dbConfig.json
+++ b/dbConfig.json
@@ -1,0 +1,8 @@
+{
+    "provided by the": "satamotodb project's docker-compose.yml",
+    "user": "",
+    "host": "",
+    "db": "",
+    "pass": "",
+    "port": 5432
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satamotodb-bitcoin-sync",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "scripts": {
     "build": "rm -rf dist/* && npm run lint && tsc",
     "lint": "tslint --project tsconfig.json",
@@ -18,7 +18,7 @@
     "typescript": "3.8.3"
   },
   "devDependencies": {},
-  "description": "Application that exports blockchain data (blocks, txs, inputs, outputs, addresses etc.) and stores them into a Postgres database. Part of the satamotodb project.",
+  "description": "Application that exports Bitcoin's blockchain data (blocks, txs, inputs, outputs, addresses etc.) and stores them into a Postgres database. Used by the satamotodb project.",
   "author": "https://github.com/tka85",
   "license": "MIT",
   "engines": {

--- a/rpcConfig.json
+++ b/rpcConfig.json
@@ -1,0 +1,8 @@
+{
+    "provided by the": "satamotodb project's docker-compose.yml",
+    "host": "",
+    "port": 8332,
+    "user": "",
+    "pass": "",
+    "timeout": 120000
+}

--- a/src/Address.ts
+++ b/src/Address.ts
@@ -1,8 +1,9 @@
 import debug = require('debug');
 import JsonRpc from './JsonRpc';
-import appConfig from './appConfig.json';
+import appConfig from '../appConfig.json';
 
 const log = appConfig.debug.address ? debug('satamoto:address') : Function.prototype;
+
 class Address {
     static chain: string;
 

--- a/src/Branch.ts
+++ b/src/Branch.ts
@@ -1,17 +1,17 @@
 import Database from "./Database";
 import debug = require('debug');
-import appConfig from './appConfig.json';
+import appConfig from '../appConfig.json';
 
 const log = appConfig.debug.branch ? debug('satamoto:Branch') : Function.prototype;
 
 class Branch {
 
-    static async addNew(forkHeight: number, parentBranchId: number): Promise<number> {
-        return await Database.addNewBranch(forkHeight, parentBranchId);
+    static async addNew(forkHeight: number, parentBranchSerial: number): Promise<number> {
+        return await Database.addNewBranch(forkHeight, parentBranchSerial);
     }
 
-    static async getBestId(): Promise<number> {
-        return await Database.getBestBranchId();
+    static async getBestSerial(): Promise<number> {
+        return await Database.getBestBranchSerial();
     }
 }
 

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -1,31 +1,26 @@
 import Database from "./Database";
 import debug = require('debug');
-import appConfig from './appConfig.json';
+import appConfig from '../appConfig.json';
 
 const log = appConfig.debug.input ? debug('satamoto:Input') : Function.prototype;
 
 class Input {
-    public blockhash: string;
-    public txid: string;
+    public _inputSerial: number;
+    public _txSerial: number;
     public vin: number;
     public seq: number;
-    public outBlockhash: string;
-    public outTxid: string;
-    public outVout: number;
+    public _outOutputSerial: number;
     public outValue: number;
     public scriptAsm: string;
     public scriptHex: string;
     public txInWitness: string[];
 
-    constructor({ blockhash, txid, vin, seq, outBlockhash, outTxid, outVout, outValue, scriptAsm, scriptHex, txInWitness }
-        : { blockhash: string, txid: string, vin: number, seq: number, outBlockhash: string, outTxid: string, outVout: number, outValue: number, scriptAsm: string, scriptHex: string, txInWitness: string[] }) {
-        this.blockhash = blockhash;
-        this.txid = txid;
+    constructor({ _txSerial, vin, seq, _outOutputSerial, outValue, scriptAsm, scriptHex, txInWitness }
+        : { _txSerial: number, vin: number, seq: number, _outOutputSerial: number, outValue: number, scriptAsm: string, scriptHex: string, txInWitness: string[] }) {
+        this._txSerial = _txSerial;
         this.vin = vin;
         this.seq = seq;
-        this.outBlockhash = outBlockhash;
-        this.outTxid = outTxid;
-        this.outVout = outVout;
+        this._outOutputSerial = _outOutputSerial;
         this.outValue = outValue;
         this.scriptAsm = scriptAsm;
         this.scriptHex = scriptHex;
@@ -33,7 +28,8 @@ class Input {
     }
 
     async save() {
-        return await Database.saveInput(this);
+        this._inputSerial = await Database.saveInput(this);
+        return Promise.resolve();
     }
 }
 

--- a/src/JsonRpc.ts
+++ b/src/JsonRpc.ts
@@ -1,8 +1,8 @@
 import debug = require('debug');
 import JsonRpc2 = require('json-rpc2');
-import appConfig from './appConfig.json';
-import rpcConfig from './rpcConfig.json';
 import JsonRpcError from './Errors/JsonRpcError';
+import appConfig from '../appConfig.json';
+import rpcConfig from '../rpcConfig.json';
 
 const log = appConfig.debug.jsonrpc ? debug('satamoto:jsonRpc') : Function.prototype;
 

--- a/src/Output.ts
+++ b/src/Output.ts
@@ -1,14 +1,14 @@
 import { Address, Script } from './types';
 import Database from './Database';
 import debug = require('debug');
-import appConfig from './appConfig.json';
+import appConfig from '../appConfig.json';
 
 const log = appConfig.debug.output ? debug('satamoto:Output') : Function.prototype;
 
 // Database tx output
 class Output {
-    public blockhash: string;
-    public txid: string;
+    public _outputSerial: number;
+    public _txSerial: number;
     public vout: number;
     public value: number;
     public addresses: string[];
@@ -17,15 +17,12 @@ class Output {
     public scriptHex: string;
     public scriptType: Script;
     public isCoinbase: boolean;
-    public _spentByBlockhash: string;
-    public _spentByTxid: string;
-    public _spentByVin: number;
+    public _spentByInputSerial: number;
     public _isSpent: boolean;
 
-    constructor({ blockhash, txid, isCoinbase, vout, value, addresses, reqSigs, scriptAsm, scriptHex, scriptType }
-        : { blockhash: string, txid: string, isCoinbase: boolean, vout: number, value: number, addresses: string[], reqSigs: number, scriptAsm: string, scriptHex: string, scriptType: Script }) {
-        this.blockhash = blockhash;
-        this.txid = txid;
+    constructor({ _txSerial, isCoinbase, vout, value, addresses, reqSigs, scriptAsm, scriptHex, scriptType }
+        : { _txSerial: number, isCoinbase: boolean, vout: number, value: number, addresses: string[], reqSigs: number, scriptAsm: string, scriptHex: string, scriptType: Script }) {
+        this._txSerial = _txSerial;
         this.isCoinbase = isCoinbase;
         this.vout = vout;
         this.value = value;
@@ -34,22 +31,21 @@ class Output {
         this.scriptAsm = scriptAsm;
         this.scriptHex = scriptHex;
         this.scriptType = scriptType;
-        this._spentByBlockhash = null;
-        this._spentByTxid = null;
-        this._spentByVin = null;
+        this._spentByInputSerial = null;
         this._isSpent = false;
     }
 
-    async save() {
-        return await Database.saveOutput(this);
+    async save(): Promise<void> {
+        this._outputSerial = await Database.saveOutput(this);
+        return Promise.resolve();
     }
 
-    static async getBlockhash({ txid, vout }: { txid: string, vout: number }): Promise<string> {
-        return await Database.getOutputBlockhash({ txid, vout });
+    static async getSerial({ txid, vout }: { txid: string, vout: number }): Promise<number> {
+        return await Database.getOutputSerial({ txid, vout });
     }
 
-    static async getValue({ blockhash, txid, vout }: { blockhash: string, txid: string, vout: number }): Promise<number> {
-        return await Database.getOutputValue({ blockhash, txid, vout });
+    static async getValue({ outputSerial }: { outputSerial: number }): Promise<number> {
+        return await Database.getOutputValue({ outputSerial });
     }
 }
 

--- a/src/Transaction.ts
+++ b/src/Transaction.ts
@@ -1,11 +1,12 @@
 import Database from "./Database";
 import debug = require('debug');
-import appConfig from './appConfig.json';
+import appConfig from '../appConfig.json';
 
 const log = appConfig.debug.tx ? debug('satamoto:Transaction') : Function.prototype;
 
 class Transaction {
-    public blockhash: string;
+    public _txSerial: number;
+    public _blockSerial: number;
     public txid: string;
     public hash: string;
     public size: string;
@@ -17,9 +18,9 @@ class Transaction {
     public isCoinbase: boolean;
     public fee: number;
 
-    constructor({ blockhash, txid, hash, size, vsize, weight, version, locktime, hex, isCoinbase }
-        : { blockhash: string, txid: string, hash: string, size: string, vsize: string, weight: string, version: number, locktime: string, hex: string, isCoinbase: boolean }) {
-        this.blockhash = blockhash;
+    constructor({ _blockSerial, txid, hash, size, vsize, weight, version, locktime, hex, isCoinbase }
+        : { _blockSerial: number, txid: string, hash: string, size: string, vsize: string, weight: string, version: number, locktime: string, hex: string, isCoinbase: boolean }) {
+        this._blockSerial = _blockSerial;
         this.txid = txid;
         this.hash = hash;
         this.size = size;
@@ -32,12 +33,17 @@ class Transaction {
     }
 
     async save(): Promise<void> {
-        return await Database.saveTransaction(this);
+        this._txSerial = await Database.saveTransaction(this);
+        return Promise.resolve();
     }
 
+    /**
+     *
+     * @param fee   {string}        fee in satoshis
+     */
     async updateFee(fee: string): Promise<void> {
         this.fee = parseInt(fee, 10);
-        return await Database.saveTransactionFee(this);
+        return await Database.updateTransactionFee(this);
     }
 }
 

--- a/src/dbConfig.json
+++ b/src/dbConfig.json
@@ -1,7 +1,0 @@
-{
-    "user": "provided",
-    "host": "by the",
-    "db": "satamotodb project's",
-    "pass": "docker-compose.yml",
-    "port": 0
-}

--- a/src/rpcConfig.json
+++ b/src/rpcConfig.json
@@ -1,7 +1,0 @@
-{
-    "host": "provided by",
-    "port": 0,
-    "user": "the satamotodb project's",
-    "pass": "docker-compose.yml",
-    "timeout": 0
-}


### PR DESCRIPTION
To reduce storage size, schema altered so that all FKs
use the corresponding serial id of the dominant entity
instead of extensive attributes (blockhash, txid etc.).
Also moves the [app|db|rpc]Config.json outside the src/ since
they are provided by the docker-compose.yml of the
satamotodb project and they don't depend on the build
of the typescript.